### PR TITLE
Switch config to the annotation system to allow in-game configuration

### DIFF
--- a/src/main/java/fluke/hexlands/Main.java
+++ b/src/main/java/fluke/hexlands/Main.java
@@ -6,8 +6,6 @@ import net.minecraftforge.fml.common.Mod.Instance;
 import net.minecraftforge.fml.common.SidedProxy;
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
-import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
-import fluke.hexlands.config.Configs;
 import fluke.hexlands.proxy.CommonProxy;
 import fluke.hexlands.util.Reference;
 import fluke.hexlands.world.WorldTypeATest;
@@ -24,12 +22,6 @@ public class Main
 	
 	@SidedProxy(clientSide = Reference.CLIENT_PROXY_CLASS, serverSide = Reference.COMMON_PROXY_CLASS)
 	public static CommonProxy proxy;
-	
-	@EventHandler
-	public static void PreInit(FMLPreInitializationEvent event)
-	{
-		Configs.loadFromFile(event.getSuggestedConfigurationFile());
-	}
 	
 	@EventHandler
 	public static void init(FMLInitializationEvent event)

--- a/src/main/java/fluke/hexlands/config/Configs.java
+++ b/src/main/java/fluke/hexlands/config/Configs.java
@@ -1,93 +1,66 @@
 package fluke.hexlands.config;
 
-import java.io.File;
+import fluke.hexlands.util.Reference;
 
-import fluke.hexlands.world.ChunkGeneratorOverworldHex;
+import net.minecraftforge.common.config.Config;
+import net.minecraftforge.common.config.ConfigManager;
+import net.minecraftforge.fml.client.event.ConfigChangedEvent;
+import net.minecraftforge.fml.common.Mod;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 
-import net.minecraft.init.Blocks;
-import net.minecraftforge.common.config.Configuration;
-import net.minecraftforge.common.config.Property;
-import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
-
+@Config(modid = Reference.MOD_ID, category = "")
+@Mod.EventBusSubscriber(modid = Reference.MOD_ID)
 public class Configs {
-	
-	public static Configuration config;
-	public static int hexSize, biomeSize, terrainHeight, terrainBaseline, lakeRarity, seaLevel, biomeHeightAdjustment, extraHexNoise;
-	public static boolean outlineAll, generateStructures, generateCaves, borderToBedrock;
-	public static String rimBlock;
-	public static final String WORLD_CONFIG = "worldgen";
 
-	public static void loadFromFile(File configFile)
-	{
-		config = new Configuration(configFile);
-		config.load();
-		loadConfigs(config);
-	}
-	
-	public static void loadConfigs(Configuration c)
-	{
-		Property prop;
-		
-		prop = c.get(WORLD_CONFIG, "hexSize", 36);
-        prop.setComment("controls size of hex tiles, larger number = bigger hex (Default: 36)");
-        hexSize = prop.getInt();
-        
-        /*
-        prop = c.get(WORLD_CONFIG, "hexHeight", 36);
-        prop.setComment("height (z-axis) of hex tiles (Default: 36)");
-        hexHeight = prop.getInt();
-        */
-        
-        prop = c.get(WORLD_CONFIG, "biomeSize", 600);
-        prop.setComment("size of biomes, lower values = larger biomes (Default: 600)");
-        biomeSize = prop.getInt();
-        
-        prop = c.get(WORLD_CONFIG, "outlineAll", false);
-        prop.setComment("draw borders around every hex (Default: false)");
-        outlineAll = prop.getBoolean();
-        
-        prop = c.get(WORLD_CONFIG, "generateStructures", true);
-        prop.setComment("generate vanilla structures: mineshaft, village, stronghold, temples... (Default: true)");
-        generateStructures = prop.getBoolean();
-        
-        prop = c.get(WORLD_CONFIG, "generateCaves", true);
-        prop.setComment("generate caves and ravines (Default: true)");
-        generateCaves = prop.getBoolean();
-        
-        prop = c.get(WORLD_CONFIG, "terrainBaseline", 66);
-        prop.setComment("height (y-level) terrain is before adjustments (Default: 66)");
-        terrainBaseline = prop.getInt();
-        
-        prop = c.get(WORLD_CONFIG, "terrainHeight", 78);
-        prop.setComment("height (y-level) terrain is adjusted by (Default: 78)");
-        terrainHeight = prop.getInt();
-        
-        prop = c.get(WORLD_CONFIG, "biomeHeightAdjustment", 18);
-        prop.setComment("how much biomes influence the final height of the hex (Default: 18)");
-        biomeHeightAdjustment = prop.getInt();
-        
-        prop = c.get(WORLD_CONFIG, "extraHexNoise", 0);
-        prop.setComment("extra height (y-level) to adjust each hex by, best used with outlineAll setting (Default: 0)");
-        extraHexNoise = prop.getInt();
-        
-        prop = c.get(WORLD_CONFIG, "seaLevel", 60);
-        prop.setComment("height (y-level) of oceans (Default: 60)");
-        seaLevel = prop.getInt();
-        
-        prop = c.get(WORLD_CONFIG, "lakeRarity", 6);
-        prop.setComment("how often lakes generate, lower numbers = more lakes (Default: 6)");
-        lakeRarity = prop.getInt();
-        
-        prop = c.get(WORLD_CONFIG, "rimBlock", "minecraft:stonebrick");
-        prop.setComment("what block to use for dividing the grid (Default: minecraft:stonebrick)");
-        rimBlock = prop.getString();
-		
-		prop = c.get(WORLD_CONFIG, "borderToBedrock", false);
-        prop.setComment("generate border block down to bedrock rather than just at the surface (Default: false)");
-        borderToBedrock = prop.getBoolean();
-        
-        c.save();
+	public static ConfigWorldGen worldgen = new ConfigWorldGen();
+
+	public static class ConfigWorldGen {
+		@Config.Comment({"Controls size of hex tiles. Larger number = Bigger hex", "Default: 36"})
+		@Config.RequiresWorldRestart
+		public int hexSize = 36;
+		@Config.Comment({"Size of biomes. Lower values = Larger biomes", "Default: 600"})
+		@Config.RequiresWorldRestart
+		public int biomeSize = 600;
+		@Config.Comment({"Height (y-level) terrain is adjusted by", "Default: 78"})
+		@Config.RequiresWorldRestart
+		public int terrainHeight = 78;
+		@Config.Comment({"Height (y-level) terrain is before adjustments", "Default: 66"})
+		@Config.RequiresWorldRestart
+		public int terrainBaseline = 66;
+		@Config.Comment({"How often lakes generate. Lower numbers = More lakes", "Default: 6"})
+		@Config.RequiresWorldRestart
+		public int lakeRarity = 6;
+		@Config.Comment({"Height (y-level) of oceans", "Default: 60"})
+		@Config.RequiresWorldRestart
+		public int seaLevel = 60;
+		@Config.Comment({"How much biomes influence the final height of the hex", "Default: 18"})
+		@Config.RequiresWorldRestart
+		public int biomeHeightAdjustment = 18;
+		@Config.Comment({"Extra height (y-level) to adjust each hex by, best used with outlineAll setting", "Default: 0"})
+		@Config.RequiresWorldRestart
+		public int extraHexNoise = 0;
+
+		@Config.Comment({"Draw borders around every hex", "Default: false"})
+		@Config.RequiresWorldRestart
+		public boolean outlineAll = false;
+		@Config.Comment({"Generate vanilla structures: mineshaft, village, stronghold, temples, etc", "Default: true"})
+		@Config.RequiresWorldRestart
+		public boolean generateStructures = true;
+		@Config.Comment({"Generate caves and ravines", "Default: true"})
+		@Config.RequiresWorldRestart
+		public boolean generateCaves = true;
+		@Config.Comment({"Generate border block down to bedrock rather than just at the surface", "Default: false"})
+		@Config.RequiresWorldRestart
+		public boolean borderToBedrock = false;
+
+		@Config.Comment({"What block to use for dividing the grid", "Default: minecraft:stonebrick"})
+		public String rimBlock = "minecraft:stonebrick";
 	}
 
+	@SubscribeEvent
+	public static void onConfigReload(ConfigChangedEvent.OnConfigChangedEvent event) {
+		if (Reference.MOD_ID.equals(event.getModID()))
+			ConfigManager.sync(Reference.MOD_ID, Config.Type.INSTANCE);
+	}
 }
 

--- a/src/main/java/fluke/hexlands/world/HexBiomeProvider.java
+++ b/src/main/java/fluke/hexlands/world/HexBiomeProvider.java
@@ -25,14 +25,13 @@ import net.minecraft.world.storage.WorldInfo;
 public class HexBiomeProvider extends BiomeProvider
 {
 
-    protected Layout hex_layout = new Layout(Layout.flat, new Point(ChunkGeneratorOverworldHex.HEX_X_SIZE, ChunkGeneratorOverworldHex.HEX_Z_SIZE), new Point(0, 0));
+    protected Layout hex_layout = new Layout(Layout.flat, new Point(Configs.worldgen.hexSize, Configs.worldgen.hexSize), new Point(0, 0));
     
     private GenLayer genBiomes;
     /** A GenLayer containing the indices into BiomeGenBase.biomeList[] */
     private GenLayer biomeIndexLayer;
     /** The biome list. */
     private final BiomeCache biomeCache;
-    public static final int BIOME_SIZE = Configs.biomeSize;
     
     public HexBiomeProvider(long seed, WorldType worldTypeIn)
     {
@@ -91,7 +90,7 @@ public class HexBiomeProvider extends BiomeProvider
             	
             	if (hexy.q != prev_hex.q || hexy.r != prev_hex.r)
             	{
-            		prev_biome = Biome.getBiome(this.biomeIndexLayer.getInts(hexy.q*BIOME_SIZE, hexy.r*BIOME_SIZE, 1, 1)[0], Biomes.DEFAULT);
+            		prev_biome = Biome.getBiome(this.biomeIndexLayer.getInts(hexy.q*Configs.worldgen.biomeSize, hexy.r*Configs.worldgen.biomeSize, 1, 1)[0], Biomes.DEFAULT);
             		prev_hex = hexy;
             	}
             	


### PR DESCRIPTION
This should retain backwards compat with existing configs. Each field is marked as requiring a world restart, so they can only be changed from the main menu, rather that in the world.